### PR TITLE
Prevent installation when azure<1.0 is present.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python
+#!/usr/bin/env python
 
 #-------------------------------------------------------------------------
 # Copyright (c) Microsoft.  All rights reserved.
@@ -17,6 +17,21 @@
 
 from setuptools import setup
 import sys
+
+# azure v0.x is not compatible with this package
+# azure v0.x used to have a __version__ attribute (newer versions don't)
+try:
+    import azure
+    try:
+        ver = azure.__version__
+        raise Exception(
+            'This package is incompatible with azure=={}. '.format(ver) +
+            'Uninstall it with "pip uninstall azure".'
+        )
+    except AttributeError:
+        pass
+except ImportError:
+    pass
 
 setup(
     name='azure-storage',


### PR DESCRIPTION
This will help some users avoid getting into trouble.
This check won't trigger when installing from a .whl, but it will for installing from sdist (on Linux)  or directly from source.
