### PR TITLE
Use requests library by default

### DIFF
--- a/azure/storage/_http/requestsclient.py
+++ b/azure/storage/_http/requestsclient.py
@@ -61,6 +61,8 @@ class _RequestsConnection(object):
     def set_tunnel(self, host, port=None, headers=None):
         self.session.proxies['http'] = 'http://{}:{}'.format(host, port)
         self.session.proxies['https'] = 'https://{}:{}'.format(host, port)
+        if headers:
+            self.session.headers.update(headers)
 
     def set_proxy_credentials(self, user, password):
         pass

--- a/azure/storage/blob/blobservice.py
+++ b/azure/storage/blob/blobservice.py
@@ -134,8 +134,7 @@ class BlobService(_StorageClient):
             http://azure.microsoft.com/en-us/documentation/articles/storage-configure-connection-string/
             for the connection string format.
         request_session:
-            Optional. Session object to use for http requests. If this is
-            specified, it replaces the default use of httplib.
+            Optional. Session object to use for http requests.
         '''
         if connection_string is not None:
             connection_params = StorageConnectionParameters(connection_string)

--- a/azure/storage/file/fileservice.py
+++ b/azure/storage/file/fileservice.py
@@ -115,8 +115,7 @@ class FileService(_StorageClient):
             http://azure.microsoft.com/en-us/documentation/articles/storage-configure-connection-string/
             for the connection string format.
         request_session:
-            Optional. Session object to use for http requests. If this is
-            specified, it replaces the default use of httplib.
+            Optional. Session object to use for http requests.
         '''
         if connection_string is not None:
             connection_params = StorageConnectionParameters(connection_string)

--- a/azure/storage/queue/queueservice.py
+++ b/azure/storage/queue/queueservice.py
@@ -111,8 +111,7 @@ class QueueService(_StorageClient):
             http://azure.microsoft.com/en-us/documentation/articles/storage-configure-connection-string/
             for the connection string format.
         request_session:
-            Optional. Session object to use for http requests. If this is
-            specified, it replaces the default use of httplib.
+            Optional. Session object to use for http requests.
         '''
         if connection_string is not None:
             connection_params = StorageConnectionParameters(connection_string)

--- a/azure/storage/storageclient.py
+++ b/azure/storage/storageclient.py
@@ -15,6 +15,8 @@
 import os
 import sys
 
+import requests
+
 from .constants import (
     AZURE_STORAGE_ACCOUNT,
     AZURE_STORAGE_ACCESS_KEY,
@@ -58,8 +60,7 @@ class _StorageClient(object):
         sas_token:
             Optional. Token to use to authenticate with shared access signature.
         request_session:
-            Optional. Session object to use for http requests. If this is
-            specified, it replaces the default use of httplib.
+            Optional. Session object to use for http requests.
         '''
         self.account_name = account_name
         self.account_key = account_key
@@ -100,7 +101,7 @@ class _StorageClient(object):
             service_instance=self,
             protocol=self.protocol,
             timeout=timeout,
-            request_session=request_session,
+            request_session=request_session or requests.Session(),
             user_agent=_USER_AGENT_STRING,
         )
         self._batchclient = None

--- a/azure/storage/table/tableservice.py
+++ b/azure/storage/table/tableservice.py
@@ -108,8 +108,7 @@ class TableService(_StorageClient):
             http://azure.microsoft.com/en-us/documentation/articles/storage-configure-connection-string/
             for the connection string format.
         request_session:
-            Optional. Session object to use for http requests. If this is
-            specified, it replaces the default use of httplib.
+            Optional. Session object to use for http requests.
         '''
         if connection_string is not None:
             connection_params = StorageConnectionParameters(connection_string)

--- a/tests/storage_testcase.py
+++ b/tests/storage_testcase.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #--------------------------------------------------------------------------
 import os.path
-from requests import Session
 from tests.common_recordingtestcase import (
     RecordingTestCase,
     TestMode,
@@ -50,11 +49,9 @@ class StorageTestCase(RecordingTestCase):
     def _create_storage_service(self, service_class, settings, account_name=None, account_key=None):
         account_name = account_name or settings.STORAGE_ACCOUNT_NAME
         account_key = account_key or settings.STORAGE_ACCOUNT_KEY
-        session = Session()
         service = service_class(
             account_name,
             account_key,
-            request_session=session,
         )
         self._set_service_options(service, settings)
         return service


### PR DESCRIPTION
With this change, we no longer use httplib directly.

If the user doesn't pass in a requests.Session() object when creating the service instance, we'll create one for them.

Note that in the previous release, we introduced the dependency on requests library, but we weren't forcibly using it.

The benefits will be improved performance due to connection pooling, and better proxy support (requests looks at various environment variables, etc to determine the correct behavior).
