### PR TITLE
Delegate proxy handling to Requests

### DIFF
--- a/azure/storage/_http/httpclient.py
+++ b/azure/storage/_http/httpclient.py
@@ -112,12 +112,13 @@ class _HTTPClient(object):
         proxy_port = self.proxy_port
 
         if self.proxy_host:
-            headers = None
-            if self.proxy_user and self.proxy_password:
-                auth = base64.encodestring(
-                    "{0}:{1}".format(self.proxy_user, self.proxy_password).encode()).rstrip()
-                headers = {'Proxy-Authorization': 'Basic {0}'.format(auth.decode())}
-            connection.set_tunnel(proxy_host, int(proxy_port), headers)
+            prepend = ''
+            if self.proxy_user:
+                prepend='{}:{}@'.format(self.proxy_user, self.proxy_password)
+               
+            rfchost = '{}{}:{}'.format(prepend, proxy_host, proxy_port)
+            
+            connection.set_tunnel(rfchost)
 
         return connection
 

--- a/azure/storage/_http/requestsclient.py
+++ b/azure/storage/_http/requestsclient.py
@@ -59,10 +59,8 @@ class _RequestsConnection(object):
         pass
 
     def set_tunnel(self, host, port=None, headers=None):
-        self.session.proxies['http'] = 'http://{}:{}'.format(host, port)
-        self.session.proxies['https'] = 'https://{}:{}'.format(host, port)
-        if headers:
-            self.session.headers.update(headers)
+        self.session.proxies['http'] = 'http://{}'.format(host)
+        self.session.proxies['https'] = 'https://{}'.format(host)
 
     def set_proxy_credentials(self, user, password):
         pass


### PR DESCRIPTION
Proxy authentication was not working at all. The 'Proxy-Authentication' header was not being sent.
 
After fiddling with requests internals/debugging it seemed to me that the best way of handling the issue was delegating everything related to proxies to requests itself.
I don't know if the idea of stripping completely set_tunnel is feasible that way, or if it breaks other azure components.