### PR TITLE
Update docs to use ContainerSharedAccessPermissions

### DIFF
--- a/doc/blob.rst
+++ b/doc/blob.rst
@@ -165,12 +165,15 @@ Alternatively, you can define a named access policy on the server:
     from azure.storage.blob import BlobService, BlobSharedAccessPermissions
     blob_service = BlobService(account_name, account_key)
 
-    policy_name = 'readonlyvaliduntilnextyear'
+    policy_name = 'readAndListValidUntilNextYear'
 
     si = SignedIdentifier()
     si.id = policy_name
     si.access_policy.expiry = '2016-01-01'
-    si.access_policy.permission = BlobSharedAccessPermissions.READ
+    si.access_policy.permission = (
+        ContainerSharedAccessPermissions.READ +
+        ContainerSharedAccessPermissions.LIST
+    )
     identifiers = SignedIdentifiers()
     identifiers.signed_identifiers.append(si)
 


### PR DESCRIPTION
I found that the examples for how to use Shared Access Signatures in the [docs](http://azure-storage.readthedocs.org/en/latest/blob.html) don't mention the "list" operation. This is likely necessary for anyone who wants to grant "read" access to a container and not a specific blob in the container.

This PR ~~adds the "list" permission to `azure.storage.blob.models.BlobSharedAccessPermissions` and~~ adds an example of how to use list permissions for containers.