### PR TITLE
Switch to emulator mode whenever you pass development credentials

### DIFF
--- a/azure/storage/storageclient.py
+++ b/azure/storage/storageclient.py
@@ -75,10 +75,15 @@ class _StorageClient(object):
         self.use_local_storage = False
 
         # check whether it is run in emulator.
+        self.is_emulated = False
         if EMULATED in os.environ:
             self.is_emulated = os.environ[EMULATED].lower() != 'false'
-        else:
-            self.is_emulated = False
+        # switch to emulator mode when dev credentials are passed, which is a much simpler
+        # way to trigger this behaviour than needing an environment variable. 
+        elif self.account_name == DEV_ACCOUNT_NAME and self.account_key == DEV_ACCOUNT_KEY:
+            self.is_emulated = True
+            self.account_name = None
+            self.account_key = None
 
         # get account_name and account key. If they are not set when
         # constructing, get the account and key from environment variables if


### PR DESCRIPTION
We didn't like to be forced to use an environment to switch to emulator mode, specifically because we have multiple instances that don't all connect to the emulator. This PR changes the behaviour a bit so that, when you don't use an environment variable, you can switch to emulator mode simply by providing the emulator credentials. Much simpler!