### PR TITLE
correct expiry type in documentation

### DIFF
--- a/azure/storage/blob/baseblobservice.py
+++ b/azure/storage/blob/baseblobservice.py
@@ -377,7 +377,7 @@ class BaseBlobService(StorageClient):
             been specified in an associated stored access policy. Azure will always 
             convert values to UTC. If a date is passed in without timezone info, it 
             is assumed to be UTC.
-        :type expiry: date or str
+        :type expiry: datetime.datetime or str
         :param start:
             The time at which the shared access signature becomes valid. If 
             omitted, start time for this call is assumed to be the time when the 


### PR DESCRIPTION
I tried using 'datetime.date' but it didn't work, so I tried 'datetime.datetime' and it did. though it would help others.
