### PR TITLE
BlockBlobService.exists leaks connections

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@
 
 ### Blob:
 - Added support for server-side encryption headers.
+- Properly return connections to pool when checking for non-existent blobs.
 
 ## Version 0.33.0:
 

--- a/azure/storage/_http/httpclient.py
+++ b/azure/storage/_http/httpclient.py
@@ -119,4 +119,7 @@ class _HTTPClient(object):
         for key, name in response.headers.items():
             respheaders[key.lower()] = name
 
-        return HTTPResponse(status, response.reason, respheaders, response.content)
+        wrap = HTTPResponse(status, response.reason, respheaders, response.content)
+        response.close()
+
+        return wrap


### PR DESCRIPTION
If the underlying blob does not exist, the connection isn't returned
back to the pool. Instead, it's left hanging in an incomplete state and
future queries end up creating new connections.

    >>> import logging
    >>> logging.basicConfig(level=logging.DEBUG)

    >>> service = BlockBlobService(...)
    >>> service.create_container('container')
    >>> service.create_blob_from_text('container', 'blob', 'some text')

The connection is properly returned to the pool when testing existence
of a blob that does exist.

    >>> service.exists('container', 'blob')
    INFO:requests.packages.urllib3.connectionpool:Starting new HTTPS connection (1): encircledevstorage.blob.core.windows.net
    DEBUG:requests.packages.urllib3.connectionpool:"HEAD /test-container/blob HTTP/1.1" 200 0
    True

    >>> service.exists('container', 'blob')
    DEBUG:requests.packages.urllib3.connectionpool:"HEAD /test-container/blob HTTP/1.1" 200 0
    True

However, if the blob does not exist, a new connection is created every
time. Note the `INFO` log lines:

    >>> # this one reuses the existing connection
    >>> service.exists('test-container', 'no-exist')
    DEBUG:requests.packages.urllib3.connectionpool:"HEAD /test-container/no-exist HTTP/1.1" 404 0
    False

    >>> # creates a new one!
    >>> service.exists('test-container', 'no-exist')
    INFO:requests.packages.urllib3.connectionpool:Starting new HTTPS connection (2): encircledevstorage.blob.core.windows.net
    DEBUG:requests.packages.urllib3.connectionpool:"HEAD /test-container/no-exist HTTP/1.1" 404 0
    False

    >>> # creates another one
    >>> service.exists('test-container', 'no-exist')
    INFO:requests.packages.urllib3.connectionpool:Starting new HTTPS connection (3): encircledevstorage.blob.core.windows.net
    DEBUG:requests.packages.urllib3.connectionpool:"HEAD /test-container/no-exist HTTP/1.1" 404 0
    False