### PR TITLE
Make make_blob_url be able to make URL for snapshot

### DIFF
--- a/azure/storage/blob/baseblobservice.py
+++ b/azure/storage/blob/baseblobservice.py
@@ -215,7 +215,8 @@ class BaseBlobService(StorageClient):
         self.key_encryption_key = None
         self.key_resolver_function = None
 
-    def make_blob_url(self, container_name, blob_name, protocol=None, sas_token=None):
+    def make_blob_url(self, container_name, blob_name,
+                      snapshot=None, protocol=None, sas_token=None):
         '''
         Creates the url to access a blob.
 
@@ -223,6 +224,9 @@ class BaseBlobService(StorageClient):
             Name of container.
         :param str blob_name:
             Name of blob.
+        :param str snapshot:
+            The snapshot parameter is an opaque DateTime value that,
+            when present, return URL of snapshot.
         :param str protocol:
             Protocol to use: 'http' or 'https'. If not specified, uses the
             protocol specified when BaseBlobService was initialized.
@@ -239,6 +243,9 @@ class BaseBlobService(StorageClient):
             container_name,
             blob_name,
         )
+
+        if snapshot:
+            url += '?snapshot=' + snapshot
 
         if sas_token:
             url += '?' + sas_token

--- a/azure/storage/blob/baseblobservice.py
+++ b/azure/storage/blob/baseblobservice.py
@@ -244,11 +244,13 @@ class BaseBlobService(StorageClient):
             blob_name,
         )
 
-        if snapshot:
-            url += '?snapshot=' + snapshot
-
-        if sas_token:
-            url += '?' + sas_token
+        if snapshot and sas_token:
+            url += '?snapshot=' + snapshot + '&' + sas_token
+        else:
+            if snapshot:
+                url += '?snapshot=' + snapshot
+            elif sas_token:
+                url += '?' + sas_token
 
         return url
 

--- a/azure/storage/blob/baseblobservice.py
+++ b/azure/storage/blob/baseblobservice.py
@@ -245,12 +245,11 @@ class BaseBlobService(StorageClient):
         )
 
         if snapshot and sas_token:
-            url += '?snapshot=' + snapshot + '&' + sas_token
-        else:
-            if snapshot:
-                url += '?snapshot=' + snapshot
-            elif sas_token:
-                url += '?' + sas_token
+            url = '{}?snapshot={}&{}'.format(url, snapshot, sas_token)
+        elif snapshot:
+            url = '{}?snapshot={}'.format(url, snapshot)
+        elif sas_token:
+            url = '{}?{}'.format(url, sas_token)
 
         return url
 

--- a/tests/test_common_blob.py
+++ b/tests/test_common_blob.py
@@ -193,6 +193,19 @@ class StorageCommonBlobTest(StorageTestCase):
                            'snapshot=2016-11-09T14:11:07.6175300Z')
 
     @record
+    def test_make_blob_url_with_snapshot_and_sas(self):
+        # Arrange
+
+        # Act
+        res = self.bs.make_blob_url('vhds', 'my.vhd', sas_token='sas',
+                                    snapshot='2016-11-09T14:11:07.6175300Z')
+
+        # Assert
+        self.assertEqual(res, 'https://' + self.settings.STORAGE_ACCOUNT_NAME
+                         + '.blob.core.windows.net/vhds/my.vhd?'
+                           'snapshot=2016-11-09T14:11:07.6175300Z&sas')
+
+    @record
     def test_create_blob_with_question_mark(self):
         # Arrange
         blob_name = '?ques?tion?'

--- a/tests/test_common_blob.py
+++ b/tests/test_common_blob.py
@@ -180,6 +180,19 @@ class StorageCommonBlobTest(StorageTestCase):
                          + '.blob.core.windows.net/vhds/my.vhd?sas')
 
     @record
+    def test_make_blob_url_with_snapshot(self):
+        # Arrange
+
+        # Act
+        res = self.bs.make_blob_url('vhds', 'my.vhd',
+                                    snapshot='2016-11-09T14:11:07.6175300Z')
+
+        # Assert
+        self.assertEqual(res, 'https://' + self.settings.STORAGE_ACCOUNT_NAME
+                         + '.blob.core.windows.net/vhds/my.vhd?'
+                           'snapshot=2016-11-09T14:11:07.6175300Z')
+
+    @record
     def test_create_blob_with_question_mark(self):
         # Arrange
         blob_name = '?ques?tion?'


### PR DESCRIPTION
When copy blob from snapshot, URL of the snapshot is needed,
this commit make make_blob_url accept snapshot as parameters.