### PR TITLE
Make make_blob_url be able to make URL for snapshot

### DIFF
--- a/azure/storage/blob/baseblobservice.py
+++ b/azure/storage/blob/baseblobservice.py
@@ -225,8 +225,8 @@ class BaseBlobService(StorageClient):
         :param str blob_name:
             Name of blob.
         :param str snapshot:
-            The snapshot parameter is an opaque DateTime value that
-            when present, return the URL of the snapshot.
+            An opaque DateTime value that when present, returns the URL of
+            the snapshot.
         :param str protocol:
             Protocol to use: 'http' or 'https'. If not specified, uses the
             protocol specified when BaseBlobService was initialized.

--- a/azure/storage/blob/baseblobservice.py
+++ b/azure/storage/blob/baseblobservice.py
@@ -215,7 +215,8 @@ class BaseBlobService(StorageClient):
         self.key_encryption_key = None
         self.key_resolver_function = None
 
-    def make_blob_url(self, container_name, blob_name, protocol=None, sas_token=None):
+    def make_blob_url(self, container_name, blob_name,
+                      snapshot=None, protocol=None, sas_token=None):
         '''
         Creates the url to access a blob.
 
@@ -223,6 +224,9 @@ class BaseBlobService(StorageClient):
             Name of container.
         :param str blob_name:
             Name of blob.
+        :param str snapshot:
+            The snapshot parameter is an opaque DateTime value that
+            when present, return the URL of the snapshot.
         :param str protocol:
             Protocol to use: 'http' or 'https'. If not specified, uses the
             protocol specified when BaseBlobService was initialized.
@@ -240,8 +244,12 @@ class BaseBlobService(StorageClient):
             blob_name,
         )
 
-        if sas_token:
-            url += '?' + sas_token
+        if snapshot and sas_token:
+            url = '{}?snapshot={}&{}'.format(url, snapshot, sas_token)
+        elif snapshot:
+            url = '{}?snapshot={}'.format(url, snapshot)
+        elif sas_token:
+            url = '{}?{}'.format(url, sas_token)
 
         return url
 

--- a/tests/test_common_blob.py
+++ b/tests/test_common_blob.py
@@ -180,6 +180,32 @@ class StorageCommonBlobTest(StorageTestCase):
                          + '.blob.core.windows.net/vhds/my.vhd?sas')
 
     @record
+    def test_make_blob_url_with_snapshot(self):
+        # Arrange
+
+        # Act
+        res = self.bs.make_blob_url('vhds', 'my.vhd',
+                                    snapshot='2016-11-09T14:11:07.6175300Z')
+
+        # Assert
+        self.assertEqual(res, 'https://' + self.settings.STORAGE_ACCOUNT_NAME
+                         + '.blob.core.windows.net/vhds/my.vhd?'
+                           'snapshot=2016-11-09T14:11:07.6175300Z')
+
+    @record
+    def test_make_blob_url_with_snapshot_and_sas(self):
+        # Arrange
+
+        # Act
+        res = self.bs.make_blob_url('vhds', 'my.vhd', sas_token='sas',
+                                    snapshot='2016-11-09T14:11:07.6175300Z')
+
+        # Assert
+        self.assertEqual(res, 'https://' + self.settings.STORAGE_ACCOUNT_NAME
+                         + '.blob.core.windows.net/vhds/my.vhd?'
+                           'snapshot=2016-11-09T14:11:07.6175300Z&sas')
+
+    @record
     def test_create_blob_with_question_mark(self):
         # Arrange
         blob_name = '?ques?tion?'


### PR DESCRIPTION
When copy blob from snapshot, URL of the snapshot is needed,
this commit make make_blob_url accept 'snapshot' as parameters,
and return the URL of the snapshot if 'snapshot' is present.