### PR TITLE
fix all non-ascii chars in docs

### DIFF
--- a/azure/storage/blob/appendblobservice.py
+++ b/azure/storage/blob/appendblobservice.py
@@ -215,14 +215,14 @@ class AppendBlobService(BaseBlobService):
             the append blob. If the Append Block operation would cause the blob
             to exceed that limit or if the blob size is already greater than the
             value specified in this header, the request will fail with
-            MaxBlobSizeConditionNotMet error (HTTP status code 412 – Precondition Failed).
+            MaxBlobSizeConditionNotMet error (HTTP status code 412 - Precondition Failed).
         :param int appendpos_condition:
             Optional conditional header, used only for the Append Block operation.
             A number indicating the byte offset to compare. Append Block will
             succeed only if the append position is equal to this number. If it
             is not, the request will fail with the
             AppendPositionConditionNotMet error
-            (HTTP status code 412 – Precondition Failed).
+            (HTTP status code 412 - Precondition Failed).
         :param str lease_id:
             Required if the blob has an active lease.
         :param datetime if_modified_since:
@@ -310,7 +310,7 @@ class AppendBlobService(BaseBlobService):
             the append blob. If the Append Block operation would cause the blob
             to exceed that limit or if the blob size is already greater than the
             value specified in this header, the request will fail with
-            MaxBlobSizeConditionNotMet error (HTTP status code 412 – Precondition Failed).
+            MaxBlobSizeConditionNotMet error (HTTP status code 412 - Precondition Failed).
         :param progress_callback:
             Callback for progress with signature function(current, total) where
             current is the number of bytes transfered so far, and total is the
@@ -372,7 +372,7 @@ class AppendBlobService(BaseBlobService):
             the append blob. If the Append Block operation would cause the blob
             to exceed that limit or if the blob size is already greater than the
             value specified in this header, the request will fail with
-            MaxBlobSizeConditionNotMet error (HTTP status code 412 – Precondition Failed).
+            MaxBlobSizeConditionNotMet error (HTTP status code 412 - Precondition Failed).
         :param progress_callback:
             Callback for progress with signature function(current, total) where
             current is the number of bytes transfered so far, and total is the
@@ -440,7 +440,7 @@ class AppendBlobService(BaseBlobService):
             the append blob. If the Append Block operation would cause the blob
             to exceed that limit or if the blob size is already greater than the
             value specified in this header, the request will fail with
-            MaxBlobSizeConditionNotMet error (HTTP status code 412 – Precondition Failed).
+            MaxBlobSizeConditionNotMet error (HTTP status code 412 - Precondition Failed).
         :param progress_callback:
             Callback for progress with signature function(current, total) where
             current is the number of bytes transfered so far, and total is the
@@ -503,7 +503,7 @@ class AppendBlobService(BaseBlobService):
             the append blob. If the Append Block operation would cause the blob
             to exceed that limit or if the blob size is already greater than the
             value specified in this header, the request will fail with
-            MaxBlobSizeConditionNotMet error (HTTP status code 412 – Precondition Failed).
+            MaxBlobSizeConditionNotMet error (HTTP status code 412 - Precondition Failed).
         :param progress_callback:
             Callback for progress with signature function(current, total) where
             current is the number of bytes transfered so far, and total is the

--- a/azure/storage/blob/baseblobservice.py
+++ b/azure/storage/blob/baseblobservice.py
@@ -2871,7 +2871,7 @@ class BaseBlobService(StorageClient):
         is in progress.
 
         When copying from a page blob, the Blob service creates a destination page 
-        blob of the source blob’s length, initially containing all zeroes. Then 
+        blob of the source blob's length, initially containing all zeroes. Then 
         the source page ranges are enumerated, and non-empty ranges are copied. 
 
         For a block blob or an append blob, the Blob service creates a committed 

--- a/azure/storage/blob/models.py
+++ b/azure/storage/blob/models.py
@@ -205,7 +205,7 @@ class CopyProperties(object):
                 Copy completed successfully.
             pending:
                 Copy is in progress. Check copy_status_description if intermittent,
-                non-fatal errors impede copy progress but don’t cause failure.
+                non-fatal errors impede copy progress but don't cause failure.
             aborted:
                 Copy was ended by Abort Copy Blob.
             failed:

--- a/azure/storage/file/_deserialization.py
+++ b/azure/storage/file/_deserialization.py
@@ -137,7 +137,7 @@ def _convert_xml_to_shares(response):
 def _convert_xml_to_directories_and_files(response):
     '''
     <?xml version="1.0" encoding="utf-8"?>
-    <EnumerationResults ServiceEndpoint="https://myaccount.file.core.windows.net/” ShareName="myshare" DirectoryPath="directory-path">
+    <EnumerationResults ServiceEndpoint="https://myaccount.file.core.windows.net/" ShareName="myshare" DirectoryPath="directory-path">
       <Marker>string-value</Marker>
       <MaxResults>int-value</MaxResults>
       <Entries>

--- a/azure/storage/file/fileservice.py
+++ b/azure/storage/file/fileservice.py
@@ -95,7 +95,7 @@ class FileService(StorageClient):
     '''
     The Server Message Block (SMB) protocol is the preferred file share protocol
     used on premise today. The Microsoft Azure File service enables customers to
-    leverage the availability and scalability of Azure’s Cloud Infrastructure as
+    leverage the availability and scalability of Azure's Cloud Infrastructure as
     a Service (IaaS) SMB without having to rewrite SMB client applications.
 
     The Azure File service also offers a compelling alternative to traditional

--- a/azure/storage/file/models.py
+++ b/azure/storage/file/models.py
@@ -225,7 +225,7 @@ class CopyProperties(object):
                 Copy completed successfully.
             pending: 
                 Copy is in progress. Check copy_status_description if intermittent,
-                non-fatal errors impede copy progress but don’t cause failure.
+                non-fatal errors impede copy progress but don't cause failure.
             aborted:
                 Copy was ended by Abort Copy File.
             failed:

--- a/azure/storage/queue/queueservice.py
+++ b/azure/storage/queue/queueservice.py
@@ -672,7 +672,7 @@ class QueueService(StorageClient):
         Access Signatures. 
         
         When you set permissions for a queue, the existing permissions are replaced. 
-        To update the queue’s permissions, call :func:`~get_queue_acl` to fetch 
+        To update the queue's permissions, call :func:`~get_queue_acl` to fetch 
         all access policies associated with the queue, modify the access policy 
         that you wish to change, and then call this function with the complete 
         set of data to perform the update.
@@ -930,9 +930,9 @@ class QueueService(StorageClient):
 
         This operation can be used to continually extend the invisibility of a 
         queue message. This functionality can be useful if you want a worker role 
-        to “lease” a queue message. For example, if a worker role calls get_messages 
+        to "lease" a queue message. For example, if a worker role calls get_messages 
         and recognizes that it needs more time to process a message, it can 
-        continually extend the message’s invisibility until it is processed. If 
+        continually extend the message's invisibility until it is processed. If 
         the worker role were to fail during processing, eventually the message 
         would become visible again and another worker role could process it.
 

--- a/azure/storage/table/tableservice.py
+++ b/azure/storage/table/tableservice.py
@@ -626,7 +626,7 @@ class TableService(StorageClient):
         Access Signatures. 
         
         When you set permissions for a table, the existing permissions are replaced. 
-        To update the table’s permissions, call :func:`~get_table_acl` to fetch 
+        To update the table's permissions, call :func:`~get_table_acl` to fetch 
         all access policies associated with the table, modify the access policy 
         that you wish to change, and then call this function with the complete 
         set of data to perform the update.


### PR DESCRIPTION
Having non-ascii chars in docs without specifying the encoding is not a good practice and is causing issues downstream. Please consider accepting these changes.

See also: https://github.com/Azure/azure-cli/issues/2939#issuecomment-295789377