### PR TITLE
Fix SAS tokens in retried requests

### DIFF
--- a/azure/storage/_auth.py
+++ b/azure/storage/_auth.py
@@ -113,6 +113,9 @@ class _StorageSASAuthentication(object):
         self.sas_token = sas_token
 
     def sign_request(self, request):
+        if request.path.endswith(self.sas_token):
+            return
+
         if '?' in request.path:
             request.path += '&'
         else:


### PR DESCRIPTION
_StorageSASAuthentication.sign_request is not idempotent, causing requests to become corrupted when they are retried (https://github.com/Azure/azure-storage-python/blob/master/azure/storage/storageclient.py#L206)