### PR TITLE
Fixed syntax error in _convert_json_response_to_entities

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,10 +2,13 @@
 
 > See [BreakingChanges](BreakingChanges.md) for a detailed list of API breaks.
 
-## Version X.X.X:
+## Version XX.XX.XX:
 
 ### Blob:
 - create_from_* and and append_blob_from_* methods will return response_properties which contains the etag and last modified time.
+
+### Table:
+- Fixed syntax error in _convert_json_response_to_entities.
 
 ## Version 0.34.3:
 - All: Made the socket timeout configurable. Increased the default socket timeout to 20 seconds.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@
 
 ### Table:
 - Fixed syntax error in _convert_json_response_to_entities.
-- Table: Fixed a bug where the urls are not correctly formed when making commit_batch to the emulator.
+- Fixed a bug where the urls are not correctly formed when making commit_batch to the emulator.
 
 ## Version 0.34.3:
 - All: Made the socket timeout configurable. Increased the default socket timeout to 20 seconds.

--- a/azure/storage/table/_deserialization.py
+++ b/azure/storage/table/_deserialization.py
@@ -253,15 +253,10 @@ def _convert_json_response_to_entities(response, property_resolver, require_encr
 
     root = loads(response.body.decode('utf-8'))
 
-    if 'value' in root:
-        for entity in root['value']:
-            entity = _decrypt_and_deserialize_entity(entity, property_resolver, require_encryption, 
-                                           key_encryption_key, key_resolver)
-            entities.append(entity)
-
-    else:
-        entities.append(_convert_json_to_entity(entity, 
-                                             property_resolver))
+    for entity in root['value']:
+        entity = _decrypt_and_deserialize_entity(entity, property_resolver, require_encryption,
+                                                 key_encryption_key, key_resolver)
+        entities.append(entity)
 
     return entities
 

--- a/tests/test_table_entity.py
+++ b/tests/test_table_entity.py
@@ -894,6 +894,17 @@ class StorageTableEntityTest(StorageTestCase):
             self._assert_default_entity(entity)
 
     @record
+    def test_query_zero_entities(self):
+        # Arrange
+        table_name = self._create_query_table(0)
+
+        # Act
+        entities = list(self.ts.query_entities(table_name))
+
+        # Assert
+        self.assertEqual(len(entities), 0)
+
+    @record
     def test_query_entities_full_metadata(self):
         # Arrange
         table_name = self._create_query_table(2)


### PR DESCRIPTION
The error was in an impossible path.