### PR TITLE
Fix issue #334 where RowKey with empty string was raising error

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,11 @@
 
 > See [BreakingChanges](BreakingChanges.md) for a detailed list of API breaks.
 
+## Version X.X.X:
+
+### Table:
+- Fixed bug where inserting entity with an empty sting as RowKey raised error.
+
 ## Version 0.35.1:
 
 ### Blob:

--- a/azure/storage/table/_error.py
+++ b/azure/storage/table/_error.py
@@ -43,7 +43,7 @@ _ERROR_VALUE_TOO_LARGE = '{0} is too large to be cast to type {1}.'
 _ERROR_UNSUPPORTED_TYPE_FOR_ENCRYPTION = 'Encryption is only supported for not None strings.'
 
 def _validate_object_has_param(param_name, object):
-    if not object.get(param_name):
+    if object.get(param_name) is None:
         raise ValueError(_ERROR_VALUE_NONE_OR_EMPTY.format(param_name))
 
 def _validate_entity(entity, encrypt=None):

--- a/tests/test_table_entity.py
+++ b/tests/test_table_entity.py
@@ -1,4 +1,4 @@
-﻿# coding: utf-8
+# coding: utf-8
 
 #-------------------------------------------------------------------------
 # Copyright (c) Microsoft.  All rights reserved.
@@ -383,6 +383,18 @@ class StorageTableEntityTest(StorageTestCase):
         # Assert
 
     @record
+    def test_insert_entity_empty_string_pk(self):
+        # Arrange
+        entity = {'RowKey': 'rk',
+                  'PartitionKey': ''}
+
+        # Act
+        resp = self.ts.insert_entity(self.table_name, entity)
+
+        # Assert
+        self.assertIsNotNone(resp)
+
+    @record
     def test_insert_entity_missing_rk(self):
         # Arrange
         entity = {'PartitionKey': 'pk'}
@@ -392,6 +404,18 @@ class StorageTableEntityTest(StorageTestCase):
             resp = self.ts.insert_entity(self.table_name, entity)
 
         # Assert
+
+    @record
+    def test_insert_entity_empty_string_rk(self):
+        # Arrange
+        entity = {'PartitionKey': 'pk',
+                  'RowKey': ''}
+
+        # Act
+        resp = self.ts.insert_entity(self.table_name, entity)
+
+        # Assert
+        self.assertIsNotNone(resp)
 
     @record
     def test_insert_entity_too_many_properties(self):


### PR DESCRIPTION
Added tests for both RowKey and PartitionKey being empty strings.