### PR TITLE
Should  "fail_on_exist=False" be default ?

### DIFF
--- a/azure-storage-blob/azure/storage/blob/baseblobservice.py
+++ b/azure-storage-blob/azure/storage/blob/baseblobservice.py
@@ -559,7 +559,7 @@ class BaseBlobService(StorageClient):
         return self._perform_request(request, _convert_xml_to_containers, operation_context=_context)
 
     def create_container(self, container_name, metadata=None,
-                         public_access=None, fail_on_exist=False, timeout=None):
+                         public_access=None, fail_on_exist=True, timeout=None):
         '''
         Creates a new container under the specified account. If the container
         with the same name already exists, the operation fails if


### PR DESCRIPTION
I often use this method "create_container" for creating a new container but I am not able to know whether the container is created until check the return value.
The function work like above because the default value of fail_on_exist is False.

Are therer any reasons why the value should be False?
I might miss some points ,so please tell me if I miss some points of view.