### PR TITLE
Info trace when 404, error trace for others

### DIFF
--- a/azure-storage-common/azure/storage/common/storageclient.py
+++ b/azure-storage-common/azure/storage/common/storageclient.py
@@ -353,12 +353,13 @@ class StorageClient(object):
                     # Sleep for the desired retry interval
                     sleep(retry_interval)
                 else:
-                    logger.error("%s Retry policy did not allow for a retry: "
-                                 "%s, HTTP status code=%s, Exception=%s.",
-                                 client_request_id_prefix,
-                                 timestamp_and_request_id,
-                                 status_code,
-                                 exception_str_in_one_line)
+                    logger_trace = logger.info if status_code == 404 else logger.error
+                    logger_trace("%s Retry policy did not allow for a retry: "
+                                     "%s, HTTP status code=%s, Exception=%s.",
+                                     client_request_id_prefix,
+                                     timestamp_and_request_id,
+                                     status_code,
+                                     exception_str_in_one_line)
                     raise ex
             finally:
                 # If this is a location locked operation and the location is not set, 


### PR DESCRIPTION
I'd like to not log at error level when an underlying lookup is raising a 404. There are other important error traces in this class that I do not want to ignore so disabling error trace here seems like an overkill. A small change like the suggested here would log at different trace level if status code is 404.

The origin of the issue in my application is that `BaseBlobService.exists` ends up writing a error trace when the blob does not exist but that is what the call itself is checking.

If there are other means to achieve a solution without changing code (configuration or something else) please let me know.

Thanks.