### PR TITLE
Update storageclient.py

### DIFF
--- a/azure-storage-common/azure/storage/common/storageclient.py
+++ b/azure-storage-common/azure/storage/common/storageclient.py
@@ -247,15 +247,15 @@ class StorageClient(object):
                     # will work as it resets the time sensitive headers.
                     _add_date_header(request)
 
+                    # Set the request context
+                    retry_context.request = request
+                    
                     try:
                         # request can be signed individually
                         self.authentication.sign_request(request)
                     except AttributeError:
                         # session can also be signed
                         self.request_session = self.authentication.signed_session(self.request_session)
-
-                    # Set the request context
-                    retry_context.request = request
 
                     # Log the request before it goes out
                     logger.info("%s Outgoing request: Method=%s, Path=%s, Query=%s, Headers=%s.",


### PR DESCRIPTION
`retry_context.request` should be set prior to signing as signing can fail, which causes the `retry` function to fail as well (as there is no request on the context).

I do however think that some exceptions should not be retried (like the one I got, which was a simple `Error`)