### PR TITLE
[Blob][BugFix]set_blob_service_properties Throws Exception When Param…

### DIFF
--- a/azure-storage-blob/azure/storage/blob/baseblobservice.py
+++ b/azure-storage-blob/azure/storage/blob/baseblobservice.py
@@ -1493,7 +1493,7 @@ class BaseBlobService(StorageClient):
 
     def set_blob_service_properties(
             self, logging=None, hour_metrics=None, minute_metrics=None,
-            cors=None, target_version=None, delete_retention_policy=None, static_website=None):
+            cors=None, target_version=None, timeout=None, delete_retention_policy=None, static_website=None):
         '''
         Sets the properties of a storage account's Blob service, including
         Azure Storage Analytics. If an element (ex Logging) is left as None, the 

--- a/azure-storage-blob/azure/storage/blob/baseblobservice.py
+++ b/azure-storage-blob/azure/storage/blob/baseblobservice.py
@@ -1534,7 +1534,7 @@ class BaseBlobService(StorageClient):
         :type static_website:
             :class:`~azure.storage.common.models.StaticWebsite`
         '''
-        if all(parameter is None for parameter in [logging, hour_metrics, minute_metrics, cors, target_version, timeout,
+        if all(parameter is None for parameter in [logging, hour_metrics, minute_metrics, cors, target_version,
                                                    delete_retention_policy, static_website]):
 
             raise ValueError("set_blob_service_properties should be called with at least one parameter")

--- a/azure-storage-blob/azure/storage/blob/baseblobservice.py
+++ b/azure-storage-blob/azure/storage/blob/baseblobservice.py
@@ -1534,6 +1534,11 @@ class BaseBlobService(StorageClient):
         :type static_website:
             :class:`~azure.storage.common.models.StaticWebsite`
         '''
+        if all(parameter is None for parameter in [logging, hour_metrics, minute_metrics, cors, target_version, timeout,
+                                                   delete_retention_policy, static_website]):
+
+            raise ValueError("set_blob_service_properties should be called with at least one non-None parameter")
+
         request = HTTPRequest()
         request.method = 'PUT'
         request.host_locations = self._get_host_locations()

--- a/azure-storage-blob/azure/storage/blob/baseblobservice.py
+++ b/azure-storage-blob/azure/storage/blob/baseblobservice.py
@@ -1493,7 +1493,7 @@ class BaseBlobService(StorageClient):
 
     def set_blob_service_properties(
             self, logging=None, hour_metrics=None, minute_metrics=None,
-            cors=None, target_version=None, timeout=None, delete_retention_policy=None, static_website=None):
+            cors=None, target_version=None, delete_retention_policy=None, static_website=None):
         '''
         Sets the properties of a storage account's Blob service, including
         Azure Storage Analytics. If an element (ex Logging) is left as None, the 
@@ -1537,7 +1537,7 @@ class BaseBlobService(StorageClient):
         if all(parameter is None for parameter in [logging, hour_metrics, minute_metrics, cors, target_version, timeout,
                                                    delete_retention_policy, static_website]):
 
-            raise ValueError("set_blob_service_properties should be called with at least one non-None parameter")
+            raise ValueError("set_blob_service_properties should be called with at least one parameter")
 
         request = HTTPRequest()
         request.method = 'PUT'

--- a/tests/common/test_service_properties.py
+++ b/tests/common/test_service_properties.py
@@ -132,6 +132,11 @@ class ServicePropertiesTest(StorageTestCase):
         self._assert_properties_default(props)
         self.assertEqual('2014-02-14', props.target_version)
 
+    def test_blob_service_properties_exception(self):
+        # if users did't provide any parameter, throw an Exception to alert them
+        with self.assertRaises(ValueError):
+            self.bs.set_blob_service_properties()
+
     @record
     def test_queue_service_properties(self):
         # Arrange


### PR DESCRIPTION
…eters are All None

set_blob_service_properties should remind the users to give correct input when the users give a bad input, while now the request is still sending out even with bad parameters.

Fixes #540.
