### PR TITLE
[File][Bug]Fix File Url

### DIFF
--- a/azure-storage-file/azure/storage/file/fileservice.py
+++ b/azure-storage-file/azure/storage/file/fileservice.py
@@ -230,7 +230,7 @@ class FileService(StorageClient):
             )
 
         if sas_token:
-            url += '?' + sas_token
+            url += (sas_token if sas_token.startswith('?') else '?' + sas_token)
 
         return url
 

--- a/tests/file/test_file.py
+++ b/tests/file/test_file.py
@@ -172,13 +172,23 @@ class StorageFileTest(StorageTestCase):
         self.assertEqual(res, 'http://' + self.settings.STORAGE_ACCOUNT_NAME
                          + '.file.core.windows.net/vhds/vhd_dir/my.vhd')
 
-    @record
     def test_make_file_url_with_sas(self):
         # Arrange
 
         # Act
         res = self.fs.make_file_url(
             'vhds', 'vhd_dir', 'my.vhd', sas_token='sas')
+
+        # Assert
+        self.assertEqual(res, 'https://' + self.settings.STORAGE_ACCOUNT_NAME +
+                         '.file.core.windows.net/vhds/vhd_dir/my.vhd?sas')
+
+    def test_make_file_url_with_sas_starts_with_question_mark(self):
+        # Arrange
+
+        # Act
+        res = self.fs.make_file_url(
+            'vhds', 'vhd_dir', 'my.vhd', sas_token='?sas')
 
         # Assert
         self.assertEqual(res, 'https://' + self.settings.STORAGE_ACCOUNT_NAME +


### PR DESCRIPTION
Currently when the sas token starts with '?' there will be two '?' in
the file url. This commit is to fix the bug.