### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,16 @@ matrix:
     - os: osx
       osx_image: xcode9.4
       language: generic
+# ppc64le specific code
+    - os: linux
+      arch: ppc64le
+      python: "2.7"
+    - os: linux
+      arch: ppc64le
+      python: "3.5"
+    - os: linux
+      arch: ppc64le
+      python: "3.6"
   allow_failures:
     - os: osx
     - python: "pypy3.5-5.8.0"


### PR DESCRIPTION
Add support for architecture ppc64le.  This is part of the Ubuntu distribution for ppc64le.
This helps us simplify testing later when distributions are re-building and re-releasing. 
The build and test results are available at the below location.
https://travis-ci.com/github/nageshlop/azure-storage-python
