### PR TITLE
Fix "is literal" Syntax Warnings

### DIFF
--- a/azure-storage-blob/azure/storage/blob/_deserialization.py
+++ b/azure-storage-blob/azure/storage/blob/_deserialization.py
@@ -638,7 +638,7 @@ def _parse_sub_response_to_http_response(sub_response):
                 num_empty_lines += 1
             elif line.startswith("x-ms-error-code".encode('utf-8')):
                 batch_http_sub_response.message = line.decode('utf-8').split(": ")[1].rstrip()
-            elif num_empty_lines is 2:
+            elif num_empty_lines == 2:
                 batch_http_sub_response.body += line
             else:
                 header = line.decode('utf-8').split(": ")[0]

--- a/azure-storage-blob/azure/storage/blob/_serialization.py
+++ b/azure-storage-blob/azure/storage/blob/_serialization.py
@@ -186,7 +186,7 @@ def _serialize_batch_body(requests, batch_id):
     :return: The body bytes for this batch.
     """
 
-    if requests is None or len(requests) is 0:
+    if requests is None or not len(requests):
         raise ValueError('Please provide sub-request(s) for this batch request')
 
     delimiter_bytes = (_get_batch_request_delimiter(batch_id, True, False) + _HTTP_LINE_ENDING).encode('utf-8')
@@ -298,7 +298,7 @@ def _serialize_query(query):
             serialized_query.append(query_value)
             serialized_query.append("&")
 
-    if len(serialized_query) is not 0:
+    if len(serialized_query):
         del serialized_query[-1]
 
     return ''.join(serialized_query)

--- a/azure-storage-blob/azure/storage/blob/blockblobservice.py
+++ b/azure-storage-blob/azure/storage/blob/blockblobservice.py
@@ -605,7 +605,7 @@ class BlockBlobService(BaseBlobService):
             data_chunk = data  # to store the chunk of data read from stream each time
 
             # keep reading from stream util length of data >= count or reaching the end of stream
-            while len(data) < count and len(data_chunk) is not 0:
+            while len(data) < count and len(data_chunk):
                 data_chunk = stream.read(count - len(data))
                 data += data_chunk
 


### PR DESCRIPTION
Using "is" with literals produces syntax warnings in Python 3.8

Copy of #695 since @D0d0 requires CLA
